### PR TITLE
Pbi-200-218 : filter email status by email

### DIFF
--- a/src/lib/redux/features/email/api.ts
+++ b/src/lib/redux/features/email/api.ts
@@ -2,6 +2,7 @@ import { api } from '@/lib/redux/services/api.ts'
 import { PaginationArgs } from '@/schemas/common.ts'
 
 import {
+  GetEmailRequestArgs,
   GetEmailStatusesResponse,
   getEmailStatusesResponseSchema,
 } from './validator.ts'
@@ -9,7 +10,7 @@ import {
 export const emailApi = api.injectEndpoints({
   overrideExisting: import.meta.env.DEV,
   endpoints: builder => ({
-    getEmailStatuses: builder.query<GetEmailStatusesResponse, PaginationArgs>({
+    getEmailStatuses: builder.query<GetEmailStatusesResponse, GetEmailRequestArgs>({
       extraOptions: { responseValidator: getEmailStatusesResponseSchema },
       query: args => ({
         method: 'GET',

--- a/src/lib/redux/features/email/api.ts
+++ b/src/lib/redux/features/email/api.ts
@@ -1,5 +1,4 @@
 import { api } from '@/lib/redux/services/api.ts'
-import { PaginationArgs } from '@/schemas/common.ts'
 
 import {
   GetEmailRequestArgs,

--- a/src/lib/redux/features/email/validator.ts
+++ b/src/lib/redux/features/email/validator.ts
@@ -1,7 +1,12 @@
 import { z } from 'zod'
 
-import { paginationSpecSchema } from '@/schemas/common.ts'
+import { PaginationArgs, paginationSpecSchema } from '@/schemas/common.ts'
 import { emailStatusSchema } from '@/schemas/email.ts'
+
+export interface GetEmailRequestArgs extends PaginationArgs {
+  email_to: string
+}
+
 
 export const getEmailStatusesResponseSchema = paginationSpecSchema.extend({
   email_status: z.array(emailStatusSchema),

--- a/src/routes/__tests__/email.test.tsx
+++ b/src/routes/__tests__/email.test.tsx
@@ -10,6 +10,17 @@ describe('<EmailPage />', () => {
     render(withWrappers(<EmailPage />))
   })
 
+  it('should render the header section with the logo', () => {
+    render(withWrappers(<EmailPage />))
+
+    const logo = screen.getByAltText('Kompas Gramedia Logo Background')
+    expect(logo).toBeInTheDocument()
+    expect(logo).toHaveAttribute('src', '/kompas-gramedia-logo-bg.svg')
+
+    expect(screen.getByText('Email Status')).toBeInTheDocument()
+    expect(screen.getByText('Lorem Ipsum')).toBeInTheDocument()
+  })
+
   it('should render email status content properly', async () => {
     render(withWrappers(<EmailPage />))
     await waitForNoLoadingOverlay()

--- a/src/routes/__tests__/email.test.tsx
+++ b/src/routes/__tests__/email.test.tsx
@@ -28,4 +28,13 @@ describe('<EmailPage />', () => {
       screen.getByTestId('email-status-table').innerText,
     ).toMatchSnapshot()
   })
+
+  it('should render input boxes for filtering by email', () => {
+    render(withWrappers(<EmailPage />))
+
+    const emailFiterInput = screen.getByTestId('filter-by-email')
+
+    expect(screen.getByPlaceholderText('Filter by Email')).toBeInTheDocument()
+    expect(emailFiterInput).toBeInTheDocument()
+  })
 })

--- a/src/routes/__tests__/email.test.tsx
+++ b/src/routes/__tests__/email.test.tsx
@@ -18,7 +18,6 @@ describe('<EmailPage />', () => {
     expect(logo).toHaveAttribute('src', '/kompas-gramedia-logo-bg.svg')
 
     expect(screen.getByText('Email Status')).toBeInTheDocument()
-    expect(screen.getByText('Lorem Ipsum')).toBeInTheDocument()
   })
 
   it('should render email status content properly', async () => {

--- a/src/routes/email.tsx
+++ b/src/routes/email.tsx
@@ -6,6 +6,11 @@ import { Footer } from '@/components/molecules/footer.tsx'
 import { useGetEmailStatusesQuery } from '@/lib/redux/features/email/api.ts'
 import { useQueryErrorHandler } from '@/lib/redux/hooks.ts'
 import { useCommonStore } from '@/lib/zustand/common.ts'
+import { Input } from '@/components/atoms/input.tsx'
+import PageHeader from '@/components/molecules/page-header.tsx'
+import { Typography } from '@/components/atoms/typography.tsx'
+
+
 
 export const Route = createFileRoute('/email')({
   component: () => <EmailPage />,
@@ -13,11 +18,13 @@ export const Route = createFileRoute('/email')({
 
 export default function EmailPage() {
   const [page, setPage] = useState<number>(1)
+  const [emailToFilter, setEmailToFilter] = useState('')
   const setShowLoadingOverlay = useCommonStore(
     state => state.setShowLoadingOverlay,
   )
   const { emails, metadata, isSuccess, error } = useGetEmailStatusesQuery(
-    { page },
+    { page, 
+      email_to: emailToFilter },
     {
       selectFromResult: result => ({
         emails: result.data?.email_status,
@@ -35,6 +42,25 @@ export default function EmailPage() {
 
   return (
     <div className="flex min-h-screen w-full flex-col items-center">
+      <PageHeader>
+        <Typography variant="h2" className="text-white">
+          Email Status
+        </Typography>
+        <Typography variant="body1" className="text-white">
+          Lorem Ipsum
+        </Typography>
+        <div className="flex w-3/4 justify-between">
+          <div className="flex-grow flex justify-stretch">
+            <Input
+              className="w-full flex-grow"
+              placeholder="Filter by Email"
+              value={emailToFilter}
+              onChange={e => setEmailToFilter(e.target.value)}
+              data-testid="filter-by-email"
+            />
+          </div>
+        </div>
+      </PageHeader>
       <div className="mt-4">
         {emails && metadata && (
           <EmailStatusTable

--- a/src/routes/email.tsx
+++ b/src/routes/email.tsx
@@ -46,9 +46,6 @@ export default function EmailPage() {
         <Typography variant="h2" className="text-white">
           Email Status
         </Typography>
-        <Typography variant="body1" className="text-white">
-          Lorem Ipsum
-        </Typography>
         <div className="flex w-3/4 justify-between">
           <div className="flex-grow flex justify-stretch">
             <Input


### PR DESCRIPTION
## Describe your changes
- Adding Page Header for email status page
- Put filter by email input and integrate

## Issue ticket number and link
https://linear.app/adudu/issue/ADU-218/integrate-filter-emailed-vendors
https://linear.app/adudu/issue/ADU-200/frontend-filter-emailed-vendors

![image](https://github.com/user-attachments/assets/0c7f7290-5a81-4e7d-a303-a95ee5491da7)